### PR TITLE
Dmc2017 415 db changes for other organization tags

### DIFF
--- a/sql/core/tables/V1_0022__organization_tables.psql
+++ b/sql/core/tables/V1_0022__organization_tables.psql
@@ -39,9 +39,7 @@ create table organization
 	favorites_count integer,
 	is_owner text,
 	owner text,
-	is_deleted boolean NOT NULL DEFAULT false,
-	production_capabilities text,
-	other_organization_tags text
+	is_deleted boolean NOT NULL DEFAULT false
 );
 ALTER TABLE organization OWNER TO gforge;
 

--- a/sql/core/tables/V1_0022__organization_tables.psql
+++ b/sql/core/tables/V1_0022__organization_tables.psql
@@ -39,7 +39,8 @@ create table organization
 	favorites_count integer,
 	is_owner text,
 	owner text,
-	is_deleted boolean NOT NULL DEFAULT false
+	is_deleted boolean NOT NULL DEFAULT false,
+	production_capabilities text
 );
 ALTER TABLE organization OWNER TO gforge;
 

--- a/sql/core/tables/V1_0022__organization_tables.psql
+++ b/sql/core/tables/V1_0022__organization_tables.psql
@@ -40,7 +40,8 @@ create table organization
 	is_owner text,
 	owner text,
 	is_deleted boolean NOT NULL DEFAULT false,
-	production_capabilities text
+	production_capabilities text,
+	other_organization_tags text
 );
 ALTER TABLE organization OWNER TO gforge;
 

--- a/sql/data/dev/V1_0027__other_organization_tags.psql
+++ b/sql/data/dev/V1_0027__other_organization_tags.psql
@@ -1,0 +1,1 @@
+ALTER TABLE organization ADD other_organization_tags text;


### PR DESCRIPTION
PAIRED WITH:

dmcFront - DMC2017-415-allow-organization-admins-to-tag-other-organizations
dmcRest -  DMC2017-415-allow-organization-admins-to-tag-other-organizations