### PR TITLE
Adding columns for dmdii membership and payment

### DIFF
--- a/sql/core/tables/V1_109_organization_add_payment_columns.psql
+++ b/sql/core/tables/V1_109_organization_add_payment_columns.psql
@@ -1,0 +1,5 @@
+ALTER TABLE organization ADD COLUMN dmdii_membership_info text;
+
+ALTER TABLE organization ADD COLUMN is_paid boolean;
+ALTER TABLE organization ALTER COLUMN is_paid SET NOT NULL;
+ALTER TABLE organization ALTER COLUMN is_paid SET DEFAULT false;

--- a/sql/core/tables/V1_109_organization_add_payment_columns.psql
+++ b/sql/core/tables/V1_109_organization_add_payment_columns.psql
@@ -1,5 +1,4 @@
 ALTER TABLE organization ADD COLUMN dmdii_membership_info text;
 
-ALTER TABLE organization ADD COLUMN is_paid boolean;
+ALTER TABLE organization ADD COLUMN is_paid boolean DEFAULT false;
 ALTER TABLE organization ALTER COLUMN is_paid SET NOT NULL;
-ALTER TABLE organization ALTER COLUMN is_paid SET DEFAULT false;


### PR DESCRIPTION
Two column additions to the organization table "dmdii_membership_info" and "is_paid" to collect additional info for membership and to set the status if an organization has paid or not.